### PR TITLE
Add support for OFED 4.9-5.1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ If you have an additional use case please update this documentation with a Pull 
   * 5.4-3.0.3.0
   * 5.4-2.4.1.3
   * 5.4-1.0.3.0
+  * 4.9-5.1.0.0
   * 4.9-4.1.7.0
   * 4.9-4.0.8.0
   * 4.9-3.1.5.0

--- a/patch-mlnxofed.sh
+++ b/patch-mlnxofed.sh
@@ -416,6 +416,13 @@ case $MLNX_OFED_VERSION in
 		RDMA_CORE_MINOR_VERSION="1.54103"
 		RDMA_CORE_NEW_VERSION="54104.versatushpc"
 		;;
+	4.9-5.1.0.0)
+		# MLNX OFED 4.9-5.1.0.0 version info
+		# https://content.mellanox.com/ofed/MLNX_OFED-4.9-5.1.0.0/MLNX_OFED_SRC-4.9-5.1.0.0.tgz
+		RDMA_CORE_VERSION="50mlnx1"
+		RDMA_CORE_MINOR_VERSION="1.49510"
+		RDMA_CORE_NEW_VERSION="49510.versatushpc"
+		;;
 	4.9-4.1.7.0)
 		# MLNX OFED 4.9-4.1.7.0 version info
 		# https://content.mellanox.com/ofed/MLNX_OFED-4.9-4.1.7.0/MLNX_OFED_SRC-4.9-4.1.7.0.tgz
@@ -511,6 +518,7 @@ case $MLNX_OFED_VERSION in
 	5.4-1.0.3.0)
 		patch_mlnx_ofed54
 		;;
+	4.9-5.1.0.0|\
 	4.9-4.1.7.0|\
 	4.9-4.0.8.0|\
 	4.9-3.1.5.0|\


### PR DESCRIPTION
Not really much of a contribution since I haven't made any modifications to the patches themselves, but it's handy that it automatically detects the last LTS version.
One thing I did notice: when installing from a local yum repo instead of the script (as a workaround suggested to me [here](https://forums.developer.nvidia.com/t/cant-build-drivers-for-ofed-4-9-in-rhel-centos-8-6-with-4-18-0-372-19-1-el8-6-x86-64-kernel/227096/3?u=torres2) when I was having problems with a recent kernel) I didn't see any missing requirements with `dnf check all` but I did see conflicts when trying to upgrade OpenMPI:
```
# dnf install openmpi4-gnu9-ohpc
Last metadata expiration check: 3:17:42 ago on Wed 26 Oct 2022 01:00:21 PM -03.
Package openmpi4-gnu9-ohpc-4.0.5-4.1.ohpc.2.1.x86_64 is already installed.
Error: 
 Problem: problem with installed package mlnx-ofed-all-user-only-4.9-5.1.0.0.rhel8.6.noarch
  - package mlnx-ofed-all-user-only-4.9-5.1.0.0.rhel8.6.noarch requires libibverbs >= 50mlnx1-1.49510, but none of the providers can be installed
  - cannot install both libibverbs-37.2-1.el8.x86_64 and libibverbs-50mlnx1-1.49510.x86_64
  - cannot install both libibverbs-50mlnx1-1.49510.x86_64 and libibverbs-37.2-1.el8.x86_64
  - package openmpi4-gnu9-ohpc-4.1.1-10.1.ohpc.2.4.x86_64 requires libefa.so.1()(64bit), but none of the providers can be installed
  - cannot install the best candidate for the job
  ```
 Obviously this was solved when I applied the patch, but I wonder if it was me making a mistake when I initially installed the components or if it's something with the yum local repo install. 