### PR TITLE
Extend verified OFED support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,17 @@ If you have an additional use case please update this documentation with a Pull 
 
 * Mellanox OFED
   * 5.5-1.0.3.2
+  * 5.4-3.7.5.0
+  * 5.4-3.6.8.1
+  * 5.4-3.5.8.0
   * 5.4-3.4.0.0
   * 5.4-3.2.7.2.3
   * 5.4-3.1.0.0
   * 5.4-3.0.3.0
   * 5.4-2.4.1.3
   * 5.4-1.0.3.0
+  * 4.9-7.1.0.0
+  * 4.9-6.0.6.0
   * 4.9-5.1.0.0
   * 4.9-4.1.7.0
   * 4.9-4.0.8.0
@@ -47,6 +52,12 @@ and you should be fine.
 The script will execute `dnf` to install the new packages, but it's up to you to
 install it or not. The resulting RPMs will be available by default on 
 `PATCHED-MLNX-OFED` directory inside `$HOME`
+
+## Verification
+
+You can verify patch applicability against upstream `rdma-core` source RPMs with:
+
+`tests/verify-releases.sh 5.4-3.7.5.0 5.4-3.6.8.1 5.4-3.5.8.0 4.9-7.1.0.0 4.9-6.0.6.0`
 
 # Open Source Apache License
 

--- a/patch-mlnxofed.sh
+++ b/patch-mlnxofed.sh
@@ -352,211 +352,269 @@ echo Patched: rdma-core.spec
 echo
 }
 
-#
-# Shell startup (main) begins here
-#
+detect_mlnx_ofed_version() {
+	if [ -n "${MLNX_OFED_VERSION_OVERRIDE:-}" ]; then
+		MLNX_OFED_VERSION=$MLNX_OFED_VERSION_OVERRIDE
+	else
+		MLNX_OFED_VERSION=`ofed_info -s | cut -f 2- -d- | cut -f 1 -d:`
+	fi
+}
 
-# Detect MLNX OFED release
-MLNX_OFED_VERSION=`ofed_info -s | cut -f 2- -d- | cut -f 1 -d:`
+load_release_metadata() {
+	case $MLNX_OFED_VERSION in
+		5.5-1.0.3.2)
+			# MLNX OFED 5.5-1.0.3.2 version info
+			# https://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_SRC-5.5-1.0.3.2.tgz
+			RDMA_CORE_VERSION="55mlnx37"
+			RDMA_CORE_MINOR_VERSION="1.55103"
+			RDMA_CORE_NEW_VERSION="55104.versatushpc"
+			PATCH_FAMILY="55"
+			;;
+		5.4-3.7.5.0)
+			# MLNX OFED 5.4-3.7.5.0 version info
+			# https://content.mellanox.com/ofed/MLNX_OFED-5.4-3.7.5.0/MLNX_OFED_SRC-5.4-3.7.5.0.tgz
+			RDMA_CORE_VERSION="54mlnx1"
+			RDMA_CORE_MINOR_VERSION="1.54375"
+			RDMA_CORE_NEW_VERSION="54376.versatushpc"
+			PATCH_FAMILY="54"
+			;;
+		5.4-3.6.8.1)
+			# MLNX OFED 5.4-3.6.8.1 version info
+			# https://content.mellanox.com/ofed/MLNX_OFED-5.4-3.6.8.1/MLNX_OFED_SRC-5.4-3.6.8.1.tgz
+			RDMA_CORE_VERSION="54mlnx1"
+			RDMA_CORE_MINOR_VERSION="1.54368"
+			RDMA_CORE_NEW_VERSION="54369.versatushpc"
+			PATCH_FAMILY="54"
+			;;
+		5.4-3.5.8.0)
+			# MLNX OFED 5.4-3.5.8.0 version info
+			# https://content.mellanox.com/ofed/MLNX_OFED-5.4-3.5.8.0/MLNX_OFED_SRC-5.4-3.5.8.0.tgz
+			RDMA_CORE_VERSION="54mlnx1"
+			RDMA_CORE_MINOR_VERSION="1.54358"
+			RDMA_CORE_NEW_VERSION="54359.versatushpc"
+			PATCH_FAMILY="54"
+			;;
+		5.4-3.4.0.0)
+			# MLNX OFED 5.4-3.4.0.0 version info
+			# https://content.mellanox.com/ofed/MLNX_OFED-5.4-3.4.0.0/MLNX_OFED_SRC-5.4-3.4.0.0.tgz
+			RDMA_CORE_VERSION="54mlnx1"
+			RDMA_CORE_MINOR_VERSION="1.54340"
+			RDMA_CORE_NEW_VERSION="54341.versatushpc"
+			PATCH_FAMILY="54"
+			;;
+		5.4-3.2.7.2.3)
+			# MLNX OFED 5.4-3.2.7.2.3 version info
+			# https://content.mellanox.com/ofed/MLNX_OFED-5.4-3.2.7.2.3/MLNX_OFED_SRC-5.4-3.2.7.2.3.tgz
+			RDMA_CORE_VERSION="54mlnx1"
+			RDMA_CORE_MINOR_VERSION="1.54327.23"
+			RDMA_CORE_NEW_VERSION="54327.24.versatushpc"
+			PATCH_FAMILY="54"
+			;;
+		5.4-3.1.0.0)
+			# MLNX OFED 5.4-3.1.0.0 version info
+			# https://content.mellanox.com/ofed/MLNX_OFED-5.4-3.1.0.0/MLNX_OFED_SRC-5.4-3.1.0.0.tgz
+			RDMA_CORE_VERSION="54mlnx1"
+			RDMA_CORE_MINOR_VERSION="1.54310"
+			RDMA_CORE_NEW_VERSION="54311.versatushpc"
+			PATCH_FAMILY="54"
+			;;
+		5.4-3.0.3.0)
+			# MLNX OFED 5.4-3.0.3.0 version info
+			# https://content.mellanox.com/ofed/MLNX_OFED-5.4-3.0.3.0/MLNX_OFED_SRC-5.4-3.0.3.0.tgz
+			RDMA_CORE_VERSION="54mlnx1"
+			RDMA_CORE_MINOR_VERSION="1.54303"
+			RDMA_CORE_NEW_VERSION="54304.versatushpc"
+			PATCH_FAMILY="54"
+			;;
+		5.4-2.4.1.3)
+			# MLNX OFED 5.4-2.4.1.3 version info
+			# https://content.mellanox.com/ofed/MLNX_OFED-5.4-2.4.1.3/MLNX_OFED_SRC-5.4-2.4.1.3.tgz
+			RDMA_CORE_VERSION="54mlnx1"
+			RDMA_CORE_MINOR_VERSION="1.54241"
+			RDMA_CORE_NEW_VERSION="54242.versatushpc"
+			PATCH_FAMILY="54"
+			;;
+		5.4-1.0.3.0)
+			# MLNX OFED 5.4-1.0.3.0 version info
+			# https://content.mellanox.com/ofed/MLNX_OFED-5.4-1.0.3.0/MLNX_OFED_SRC-5.4-1.0.3.0.tgz
+			RDMA_CORE_VERSION="54mlnx1"
+			RDMA_CORE_MINOR_VERSION="1.54103"
+			RDMA_CORE_NEW_VERSION="54104.versatushpc"
+			PATCH_FAMILY="54"
+			;;
+		4.9-7.1.0.0)
+			# MLNX OFED 4.9-7.1.0.0 version info
+			# https://content.mellanox.com/ofed/MLNX_OFED-4.9-7.1.0.0/MLNX_OFED_SRC-4.9-7.1.0.0.tgz
+			RDMA_CORE_VERSION="50mlnx1"
+			RDMA_CORE_MINOR_VERSION="1.49710"
+			RDMA_CORE_NEW_VERSION="49711.versatushpc"
+			PATCH_FAMILY="49"
+			;;
+		4.9-6.0.6.0)
+			# MLNX OFED 4.9-6.0.6.0 version info
+			# https://content.mellanox.com/ofed/MLNX_OFED-4.9-6.0.6.0/MLNX_OFED_SRC-4.9-6.0.6.0.tgz
+			RDMA_CORE_VERSION="50mlnx1"
+			RDMA_CORE_MINOR_VERSION="1.49606"
+			RDMA_CORE_NEW_VERSION="49607.versatushpc"
+			PATCH_FAMILY="49"
+			;;
+		4.9-5.1.0.0)
+			# MLNX OFED 4.9-5.1.0.0 version info
+			# https://content.mellanox.com/ofed/MLNX_OFED-4.9-5.1.0.0/MLNX_OFED_SRC-4.9-5.1.0.0.tgz
+			RDMA_CORE_VERSION="50mlnx1"
+			RDMA_CORE_MINOR_VERSION="1.49510"
+			RDMA_CORE_NEW_VERSION="49510.versatushpc"
+			PATCH_FAMILY="49"
+			;;
+		4.9-4.1.7.0)
+			# MLNX OFED 4.9-4.1.7.0 version info
+			# https://content.mellanox.com/ofed/MLNX_OFED-4.9-4.1.7.0/MLNX_OFED_SRC-4.9-4.1.7.0.tgz
+			RDMA_CORE_VERSION="50mlnx1"
+			RDMA_CORE_MINOR_VERSION="1.49417"
+			RDMA_CORE_NEW_VERSION="49418.versatushpc"
+			PATCH_FAMILY="49"
+			;;
+		4.9-4.0.8.0)
+			# MLNX OFED 4.9-4.0.8.0 version info
+			# https://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_SRC-4.9-4.0.8.0.tgz
+			RDMA_CORE_VERSION="50mlnx1"
+			RDMA_CORE_MINOR_VERSION="1.49408"
+			RDMA_CORE_NEW_VERSION="49409.versatushpc"
+			PATCH_FAMILY="49"
+			;;
+		4.9-3.1.5.0)
+			# MLNX OFED 4.9-3.1.5.0 version info
+			# https://content.mellanox.com/ofed/MLNX_OFED-4.9-3.1.5.0/MLNX_OFED_SRC-4.9-3.1.5.0.tgz
+			RDMA_CORE_VERSION="50mlnx1"
+			RDMA_CORE_MINOR_VERSION="1.49315"
+			RDMA_CORE_NEW_VERSION="49316.versatushpc"
+			PATCH_FAMILY="49"
+			;;
+		4.9-2.2.6.0)
+			# MLNX OFED 4.9-2.2.6.0 version info
+			# https://content.mellanox.com/ofed/MLNX_OFED-4.9-2.2.6.0/MLNX_OFED_SRC-4.9-2.2.6.0.tgz
+			RDMA_CORE_VERSION="50mlnx1"
+			RDMA_CORE_MINOR_VERSION="1.49226"
+			RDMA_CORE_NEW_VERSION="49227.versatushpc"
+			PATCH_FAMILY="49"
+			;;
+		4.9-2.2.4.0)
+			# MLNX OFED 4.9-2.2.4.0 version info
+			# https://content.mellanox.com/ofed/MLNX_OFED-4.9-2.2.4.0/MLNX_OFED_SRC-4.9-2.2.4.0.tgz
+			RDMA_CORE_VERSION="50mlnx1"
+			RDMA_CORE_MINOR_VERSION="1.49224"
+			RDMA_CORE_NEW_VERSION="49225.versatushpc"
+			PATCH_FAMILY="49"
+			;;
+		4.9-0.1.7.0)
+			# MLNX OFED 4.9-0.1.7.0 version info
+			# https://content.mellanox.com/ofed/MLNX_OFED-4.9-0.1.7.0/MLNX_OFED_SRC-4.9-0.1.7.0.tgz
+			RDMA_CORE_VERSION="50mlnx1"
+			RDMA_CORE_MINOR_VERSION="1.49017"
+			RDMA_CORE_NEW_VERSION="49018.versatushpc"
+			PATCH_FAMILY="49"
+			;;
+		*)
+			return 1
+			;;
+	esac
+	return 0
+}
 
-if [ -z $MLNX_OFED_VERSION ]; then
-	echo Cannot detect MLNX OFED, is it installed?
-	exit
-else
-	echo Detected MLNX OFED release: $MLNX_OFED_VERSION
-fi
+apply_release_patch() {
+	case $PATCH_FAMILY in
+		55)
+			patch_mlnx_ofed55
+			;;
+		54)
+			patch_mlnx_ofed54
+			;;
+		49)
+			patch_mlnx_ofed49
+			;;
+		*)
+			echo "Unsupported MLNX OFED release: $MLNX_OFED_VERSION"
+			return 1
+			;;
+	esac
+}
 
-case $MLNX_OFED_VERSION in
-	5.5-1.0.3.2)
-		# MLNX OFED 5.5-1.0.3.2 version info
-		# https://content.mellanox.com/ofed/MLNX_OFED-5.5-1.0.3.2/MLNX_OFED_SRC-5.5-1.0.3.2.tgz
-		RDMA_CORE_VERSION="55mlnx37"
-		RDMA_CORE_MINOR_VERSION="1.55103"
-		RDMA_CORE_NEW_VERSION="55104.versatushpc"
-		;;
-	5.4-3.4.0.0)
-		# MLNX OFED 5.4-3.4.0.0 version info
-		# https://content.mellanox.com/ofed/MLNX_OFED-5.4-3.4.0.0/MLNX_OFED_SRC-5.4-3.4.0.0.tgz
-		RDMA_CORE_VERSION="54mlnx1"
-		RDMA_CORE_MINOR_VERSION="1.54340"
-		RDMA_CORE_NEW_VERSION="54341.versatushpc"
-		;;
-	5.4-3.2.7.2.3)
-		# MLNX OFED 5.4-3.2.7.2.3 version info
-		# https://content.mellanox.com/ofed/MLNX_OFED-5.4-3.2.7.2.3/MLNX_OFED_SRC-5.4-3.2.7.2.3.tgz
-		RDMA_CORE_VERSION="54mlnx1"
-		RDMA_CORE_MINOR_VERSION="1.54327"
-		RDMA_CORE_NEW_VERSION="54328.versatushpc"
-		;;
-	5.4-3.1.0.0)
-		# MLNX OFED 5.4-3.1.0.0 version info
-		# https://content.mellanox.com/ofed/MLNX_OFED-5.4-3.1.0.0/MLNX_OFED_SRC-5.4-3.1.0.0.tgz
-		RDMA_CORE_VERSION="54mlnx1"
-		RDMA_CORE_MINOR_VERSION="1.54310"
-		RDMA_CORE_NEW_VERSION="54311.versatushpc"
-		;;
-	5.4-3.0.3.0)
-		# MLNX OFED 5.4-3.0.3.0 version info
-		# https://content.mellanox.com/ofed/MLNX_OFED-5.4-3.0.3.0/MLNX_OFED_SRC-5.4-3.0.3.0.tgz
-		RDMA_CORE_VERSION="54mlnx1"
-		RDMA_CORE_MINOR_VERSION="1.54303"
-		RDMA_CORE_NEW_VERSION="54304.versatushpc"
-		;;
-	5.4-2.4.1.3)
-		# MLNX OFED 5.4-2.4.1.3 version info
-		# https://content.mellanox.com/ofed/MLNX_OFED-5.4-2.4.1.3/MLNX_OFED_SRC-5.4-2.4.1.3.tgz
-		RDMA_CORE_VERSION="54mlnx1"
-		RDMA_CORE_MINOR_VERSION="1.54241"
-		RDMA_CORE_NEW_VERSION="54242.versatushpc"
-		;;
-	5.4-1.0.3.0)
-		# MLNX OFED 5.4-1.0.3.0 version info
-		# https://content.mellanox.com/ofed/MLNX_OFED-5.4-1.0.3.0/MLNX_OFED_SRC-5.4-1.0.3.0.tgz
-		RDMA_CORE_VERSION="54mlnx1"
-		RDMA_CORE_MINOR_VERSION="1.54103"
-		RDMA_CORE_NEW_VERSION="54104.versatushpc"
-		;;
-	4.9-5.1.0.0)
-		# MLNX OFED 4.9-5.1.0.0 version info
-		# https://content.mellanox.com/ofed/MLNX_OFED-4.9-5.1.0.0/MLNX_OFED_SRC-4.9-5.1.0.0.tgz
-		RDMA_CORE_VERSION="50mlnx1"
-		RDMA_CORE_MINOR_VERSION="1.49510"
-		RDMA_CORE_NEW_VERSION="49510.versatushpc"
-		;;
-	4.9-4.1.7.0)
-		# MLNX OFED 4.9-4.1.7.0 version info
-		# https://content.mellanox.com/ofed/MLNX_OFED-4.9-4.1.7.0/MLNX_OFED_SRC-4.9-4.1.7.0.tgz
-		RDMA_CORE_VERSION="50mlnx1"
-		RDMA_CORE_MINOR_VERSION="1.49417"
-		RDMA_CORE_NEW_VERSION="49418.versatushpc"
-		;;
-	4.9-4.0.8.0)
-		# MLNX OFED 4.9-4.0.8.0 version info
-		# https://content.mellanox.com/ofed/MLNX_OFED-4.9-4.0.8.0/MLNX_OFED_SRC-4.9-4.0.8.0.tgz
-		RDMA_CORE_VERSION="50mlnx1"
-		RDMA_CORE_MINOR_VERSION="1.49408"
-		RDMA_CORE_NEW_VERSION="49409.versatushpc"
-		;;
-	4.9-3.1.5.0)
-		# MLNX OFED 4.9-3.1.5.0 version info
-		# https://content.mellanox.com/ofed/MLNX_OFED-4.9-3.1.5.0/MLNX_OFED_SRC-4.9-3.1.5.0.tgz
-		RDMA_CORE_VERSION="50mlnx1"
-		RDMA_CORE_MINOR_VERSION="1.49315"
-		RDMA_CORE_NEW_VERSION="49316.versatushpc"
-		;;
-	4.9-2.2.6.0)
-		# MLNX OFED 4.9-2.2.6.0 version info
-		# https://content.mellanox.com/ofed/MLNX_OFED-4.9-2.2.6.0/MLNX_OFED_SRC-4.9-2.2.6.0.tgz
-		RDMA_CORE_VERSION="50mlnx1"
-		RDMA_CORE_MINOR_VERSION="1.49226"
-		RDMA_CORE_NEW_VERSION="49227.versatushpc"
-		;;
-	4.9-2.2.4.0)
-		# MLNX OFED 4.9-2.2.4.0 version info
-		# https://content.mellanox.com/ofed/MLNX_OFED-4.9-2.2.4.0/MLNX_OFED_SRC-4.9-2.2.4.0.tgz
-		RDMA_CORE_VERSION="50mlnx1"
-		RDMA_CORE_MINOR_VERSION="1.49224"
-		RDMA_CORE_NEW_VERSION="49225.versatushpc"
-		;;
-	4.9-0.1.7.0)
-		# MLNX OFED 4.9-0.1.7.0 version info
-		# https://content.mellanox.com/ofed/MLNX_OFED-4.9-0.1.7.0/MLNX_OFED_SRC-4.9-0.1.7.0.tgz
-		RDMA_CORE_VERSION="50mlnx1"
-		RDMA_CORE_MINOR_VERSION="1.49017"
-		RDMA_CORE_NEW_VERSION="49018.versatushpc"
-		;;
-	*)
-		# Unsupported MLNX OFED release
+main() {
+	detect_mlnx_ofed_version
+
+	if [ -z "$MLNX_OFED_VERSION" ]; then
+		echo Cannot detect MLNX OFED, is it installed?
+		exit 1
+	else
+		echo Detected MLNX OFED release: $MLNX_OFED_VERSION
+	fi
+
+	if ! load_release_metadata; then
 		echo "Unsupported MLNX OFED release: $MLNX_OFED_VERSION"
-		exit
-		;;
-esac
+		exit 1
+	fi
 
-# Create the directory structure to build the packages
-mkdir -p $RPM_BUILD_ROOT/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
-mkdir -p $WORK_DIR
-cd $WORK_DIR
+	mkdir -p $RPM_BUILD_ROOT/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+	mkdir -p $WORK_DIR
+	cd $WORK_DIR
 
-# Install required packages for building
-echo Installing required dependencies...
-# Workaround for conflicting Cython from OpenHPC 2.x
-if rpm -q --quiet python3-Cython-ohpc ; then
-	dnf remove -y python3-Cython-ohpc
+	echo Installing required dependencies...
+	if rpm -q --quiet python3-Cython-ohpc ; then
+		dnf remove -y python3-Cython-ohpc
+	fi
+	dnf install -y kernel-rpm-macros rpm-build patch pandoc cmake3 systemd-devel python3-devel libnl3-devel python3-Cython perl-generators
+	echo
+
+	if [ ! -f MLNX_OFED_SRC-$MLNX_OFED_VERSION.tgz ] ; then
+		echo Downloading MLNX OFED $MLNX_OFED_VERSION sources...
+		curl -O https://content.mellanox.com/ofed/MLNX_OFED-$MLNX_OFED_VERSION/MLNX_OFED_SRC-$MLNX_OFED_VERSION.tgz
+	fi
+	echo
+
+	tar zxf MLNX_OFED_SRC-$MLNX_OFED_VERSION.tgz
+	echo Extracting files from SRPMS...
+	rpm2cpio MLNX_OFED_SRC-$MLNX_OFED_VERSION/SRPMS/rdma-core-$RDMA_CORE_VERSION-$RDMA_CORE_MINOR_VERSION.src.rpm | cpio -i
+	echo
+
+	tar zxf rdma-core-$RDMA_CORE_VERSION.tgz
+	cd rdma-core-$RDMA_CORE_VERSION
+
+	echo Patching MLNX OFED to add back support for MLX4 and EFA...
+	echo
+	sleep 1
+
+	if ! apply_release_patch; then
+		exit 1
+	fi
+
+	cp -f rdma-core.spec ..
+	cd ..
+
+	sed -i s/Release:.*/Release:\ $RDMA_CORE_NEW_VERSION/g rdma-core.spec
+	sed -i s/Source:.*/Source:\ rdma-core-%{version}-%{release}.tgz/g rdma-core.spec
+
+	tar czf rdma-core-$RDMA_CORE_VERSION-$RDMA_CORE_NEW_VERSION.tgz rdma-core-$RDMA_CORE_VERSION
+	cp rdma-core-$RDMA_CORE_VERSION-$RDMA_CORE_NEW_VERSION.tgz $RPM_BUILD_ROOT/SOURCES
+
+	echo Building RPMS... it may take a while
+	rpmbuild --nodebuginfo --define "_topdir $RPM_BUILD_ROOT" -ba rdma-core.spec 2>/dev/null >/dev/null
+
+	mkdir -p $RPMS_OUTPUT_DIR
+	mv $RPM_BUILD_ROOT/RPMS/x86_64/* $RPMS_OUTPUT_DIR
+
+	cd $RPMS_OUTPUT_DIR
+	dnf install *
+
+	rm -rf $WORK_DIR
+	rm -rf $RPM_BUILD_ROOT
+
+	echo
+	echo Mellanox OFED installation has been patched for EFA \(libefa.so\) and MLX4 \(libmlx4.so\) support
+	echo RPM packages are available at $RPMS_OUTPUT_DIR
+	echo
+	echo Done
+}
+
+if [ "${PATCH_MLNXOFED_LIBRARY_MODE:-0}" != "1" ]; then
+	main "$@"
 fi
-dnf install -y kernel-rpm-macros rpm-build patch pandoc cmake3 systemd-devel python3-devel libnl3-devel python3-Cython perl-generators
-echo
-
-# We can try to save some bandwidth if the SRC file is already in place, probably not...
-if [ ! -f MLNX_OFED_SRC-$MLNX_OFED_VERSION.tgz ] ; then
-	echo Downloading MLNX OFED $MLNX_OFED_VERSION sources...
-	curl -O https://content.mellanox.com/ofed/MLNX_OFED-$MLNX_OFED_VERSION/MLNX_OFED_SRC-$MLNX_OFED_VERSION.tgz
-fi
-echo
-
-tar zxf MLNX_OFED_SRC-$MLNX_OFED_VERSION.tgz
-echo Extracting files from SRPMS...
-rpm2cpio MLNX_OFED_SRC-$MLNX_OFED_VERSION/SRPMS/rdma-core-$RDMA_CORE_VERSION-$RDMA_CORE_MINOR_VERSION.src.rpm | cpio -i
-echo
-
-tar zxf rdma-core-$RDMA_CORE_VERSION.tgz
-cd rdma-core-$RDMA_CORE_VERSION
-
-echo Patching MLNX OFED to add back support for MLX4 and EFA...
-echo
-sleep 1
-
-# This case statement will handle patching for different releases
-case $MLNX_OFED_VERSION in
-	5.5-1.0.3.2)
-		patch_mlnx_ofed55
-		;;
-	5.4-3.4.0.0|\
-	5.4-3.2.7.2.3|\
-	5.4-3.1.0.0|\
-	5.4-3.0.3.0|\
-	5.4-2.4.1.3|\
-	5.4-1.0.3.0)
-		patch_mlnx_ofed54
-		;;
-	4.9-5.1.0.0|\
-	4.9-4.1.7.0|\
-	4.9-4.0.8.0|\
-	4.9-3.1.5.0|\
-	4.9-2.2.6.0|\
-	4.9-2.2.4.0|\
-	4.9-0.1.7.0)
-		patch_mlnx_ofed49
-		;;
-esac
-
-# Copy specfile to outside of the package
-cp -f rdma-core.spec ..
-cd ..
-
-# Increase the version number and add the distro tag
-sed -i s/Release:.*/Release:\ $RDMA_CORE_NEW_VERSION/g rdma-core.spec
-sed -i s/Source:.*/Source:\ rdma-core-%{version}-%{release}.tgz/g rdma-core.spec
-
-tar czf rdma-core-$RDMA_CORE_VERSION-$RDMA_CORE_NEW_VERSION.tgz rdma-core-$RDMA_CORE_VERSION
-cp rdma-core-$RDMA_CORE_VERSION-$RDMA_CORE_NEW_VERSION.tgz $RPM_BUILD_ROOT/SOURCES
-
-# Rebuild rdma-core
-echo Building RPMS... it may take a while
-rpmbuild --nodebuginfo --define "_topdir $RPM_BUILD_ROOT" -ba rdma-core.spec 2>/dev/null >/dev/null
-
-mkdir -p $RPMS_OUTPUT_DIR
-mv $RPM_BUILD_ROOT/RPMS/x86_64/* $RPMS_OUTPUT_DIR
-
-# We don't want to install with -y; it's a safety measure
-cd $RPMS_OUTPUT_DIR
-dnf install *
-
-# Cleanup
-rm -rf $WORK_DIR
-rm -rf $RPM_BUILD_ROOT
-
-echo
-echo Mellanox OFED installation has been patched for EFA \(libefa.so\) and MLX4 \(libmlx4.so\) support
-echo RPM packages are available at $RPMS_OUTPUT_DIR
-echo
-echo Done

--- a/tests/verify-releases.sh
+++ b/tests/verify-releases.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "$script_dir/.." && pwd)
+cache_dir=${VERIFY_RELEASES_CACHE_DIR:-"${XDG_CACHE_HOME:-$HOME/.cache}/mlnxofed-patch/verify-releases"}
+
+if [ "$#" -eq 0 ]; then
+	echo "Usage: $0 <mlnx-ofed-version> [<mlnx-ofed-version> ...]" >&2
+	exit 1
+fi
+
+for tool in curl rpm2cpio cpio tar patch rg; do
+	if ! command -v "$tool" >/dev/null 2>&1; then
+		echo "Missing required tool: $tool" >&2
+		exit 1
+	fi
+done
+
+mkdir -p "$cache_dir"
+work_root=$(mktemp -d)
+trap 'rm -rf "$work_root"' EXIT
+
+PATCH_MLNXOFED_LIBRARY_MODE=1 . "$repo_root/patch-mlnxofed.sh"
+
+download_source_rpm() {
+	local version="$1"
+	local rpm_name="$2"
+	local release_root="$3"
+	local rpm_path="$4"
+	local source_bundle_name="MLNX_OFED_SRC-$version.tgz"
+	local source_bundle_cache_path="$cache_dir/$source_bundle_name"
+
+	if curl -fsSL "https://linux.mellanox.com/public/repo/mlnx_ofed/$version/SRPMS/$rpm_name" -o "$rpm_path"; then
+		return 0
+	fi
+
+	if [ ! -f "$source_bundle_cache_path" ]; then
+		if ! curl -fsSL "https://linux.mellanox.com/public/repo/mlnx_ofed/$version/$source_bundle_name" -o "$source_bundle_cache_path"; then
+			curl -fsSL "https://content.mellanox.com/ofed/MLNX_OFED-$version/$source_bundle_name" -o "$source_bundle_cache_path"
+		fi
+	fi
+
+	tar zxf "$source_bundle_cache_path" -C "$release_root"
+	cp "$release_root/MLNX_OFED_SRC-$version/SRPMS/$rpm_name" "$rpm_path"
+}
+
+verify_release() {
+	local version="$1"
+	local rpm_name
+	local rpm_cache_path
+	local release_root
+
+	MLNX_OFED_VERSION="$version"
+	if ! load_release_metadata; then
+		echo "FAIL $version unsupported release metadata"
+		return 1
+	fi
+
+	rpm_name="rdma-core-$RDMA_CORE_VERSION-$RDMA_CORE_MINOR_VERSION.src.rpm"
+	rpm_cache_path="$cache_dir/$rpm_name"
+	release_root="$work_root/$version"
+
+	if [ ! -f "$rpm_cache_path" ]; then
+		download_source_rpm "$version" "$rpm_name" "$work_root" "$rpm_cache_path"
+	fi
+
+	mkdir -p "$release_root"
+	cp "$rpm_cache_path" "$release_root/"
+
+	cd "$release_root"
+	rpm2cpio "$rpm_name" | cpio -idm >/dev/null 2>&1
+	tar zxf "rdma-core-$RDMA_CORE_VERSION.tgz"
+	cd "rdma-core-$RDMA_CORE_VERSION"
+
+	apply_release_patch >/dev/null
+
+	rg -F 'add_subdirectory(providers/efa)' CMakeLists.txt >/dev/null
+	rg -F '%{_libdir}/libefa.so.*' rdma-core.spec >/dev/null
+
+	echo "PASS $version"
+}
+
+for version in "$@"; do
+	verify_release "$version"
+done

--- a/tests/verify-releases.sh
+++ b/tests/verify-releases.sh
@@ -1,9 +1,18 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-set -euo pipefail
+set -eu
 
-script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-repo_root=$(cd "$script_dir/.." && pwd)
+case $0 in
+	*/*)
+		self_path=$0
+		;;
+	*)
+		self_path=$(command -v "$0" 2>/dev/null || printf '%s\n' "$0")
+		;;
+esac
+
+script_dir=$(CDPATH= cd "$(dirname "$self_path")" && pwd)
+repo_root=$(CDPATH= cd "$script_dir/.." && pwd)
 cache_dir=${VERIFY_RELEASES_CACHE_DIR:-"${XDG_CACHE_HOME:-$HOME/.cache}/mlnxofed-patch/verify-releases"}
 
 if [ "$#" -eq 0 ]; then
@@ -20,17 +29,17 @@ done
 
 mkdir -p "$cache_dir"
 work_root=$(mktemp -d)
-trap 'rm -rf "$work_root"' EXIT
+trap 'rm -rf "$work_root"' 0
 
 PATCH_MLNXOFED_LIBRARY_MODE=1 . "$repo_root/patch-mlnxofed.sh"
 
 download_source_rpm() {
-	local version="$1"
-	local rpm_name="$2"
-	local release_root="$3"
-	local rpm_path="$4"
-	local source_bundle_name="MLNX_OFED_SRC-$version.tgz"
-	local source_bundle_cache_path="$cache_dir/$source_bundle_name"
+	version=$1
+	rpm_name=$2
+	release_root=$3
+	rpm_path=$4
+	source_bundle_name="MLNX_OFED_SRC-$version.tgz"
+	source_bundle_cache_path="$cache_dir/$source_bundle_name"
 
 	if curl -fsSL "https://linux.mellanox.com/public/repo/mlnx_ofed/$version/SRPMS/$rpm_name" -o "$rpm_path"; then
 		return 0
@@ -47,10 +56,7 @@ download_source_rpm() {
 }
 
 verify_release() {
-	local version="$1"
-	local rpm_name
-	local rpm_cache_path
-	local release_root
+	version=$1
 
 	MLNX_OFED_VERSION="$version"
 	if ! load_release_metadata; then


### PR DESCRIPTION
## What changed
This extends the existing supported MLNX OFED matrix within the already-supported `4.9` and `5.4` patch families.

Added releases:
- `5.4-3.5.8.0`
- `5.4-3.6.8.1`
- `5.4-3.7.5.0`
- `4.9-6.0.6.0`
- `4.9-7.1.0.0`

The patching flow was also refactored so release metadata and patch-family dispatch are defined once and can be sourced by tests.

## Why
The repo already had working patch families for `4.9`, `5.4`, and `5.5`, but some later point releases in the `4.9` and `5.4` families were missing from the support table even though they reuse the same patch logic.

While validating the matrix, this also uncovered a pre-existing metadata bug for `5.4-3.2.7.2.3`: the upstream source RPM release is `1.54327.23`, not `1.54327`.

## Impact
Users can now patch the missing `4.9` and `5.4` releases without adding new patch families, and the repo now includes a reproducible verifier for declared support.

## Validation
Checks run locally:
- `sh -n patch-mlnxofed.sh`
- `bash -n tests/verify-releases.sh`
- `./tests/verify-releases.sh 5.5-1.0.3.2 5.4-3.7.5.0 5.4-3.6.8.1 5.4-3.5.8.0 5.4-3.4.0.0 5.4-3.2.7.2.3 5.4-3.1.0.0 5.4-3.0.3.0 5.4-2.4.1.3 5.4-1.0.3.0 4.9-7.1.0.0 4.9-6.0.6.0 4.9-5.1.0.0 4.9-4.1.7.0 4.9-4.0.8.0 4.9-3.1.5.0 4.9-2.2.6.0 4.9-2.2.4.0 4.9-0.1.7.0`

That final verification run passed for all 19 declared supported releases.