### PR TITLE
Add EL9 build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,18 @@ and [oVirt](https://www.ovirt.org) with Openvswitch
 If you have an additional use case please update this documentation with a Pull Request.
 
 ## Requirements:
-* Enterprise Linux 8
+* Enterprise Linux 8 or 9
   * Red Hat Enterprise Linux (RHEL)
   * Oracle Linux
   * Rocky Linux
   * Alma Linux
   * CentOS
 
-* CodeReady Builder / PowerTools repositories must be enabled
+* Enterprise Linux 8
+  * CodeReady Builder / PowerTools repositories must be enabled
+* Enterprise Linux 9
+  * CRB must be enabled
+  * EPEL is required for `pandoc`
 * root privileges are needed for installation
 
 ## Supported MLNX OFED releases

--- a/patch-mlnxofed.sh
+++ b/patch-mlnxofed.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Patch to add back support for MLX4 and EFA on MLNX OFED
-# This script is only tested against Enterprise Linux 8
+# This script is tested against Enterprise Linux 8 and 9
 #
 # vinicius {\a\t} ferrao.net.br
 # ferrao {\a\t} versatushpc.com.br
@@ -29,6 +29,42 @@ patch_checked() {
 		cat "$patch_target.rej" >&2
 		return 1
 	fi
+}
+
+dnf_install_args() {
+	el_major=$(rpm -E '%{?rhel}')
+
+	if [ "$el_major" = 9 ]; then
+		echo "-y --nobest"
+	else
+		echo "-y"
+	fi
+}
+
+install_required_dependencies() {
+	el_major=$(rpm -E '%{?rhel}')
+	cmake_package=
+	dnf_args=$(dnf_install_args)
+
+	case "$el_major" in
+	8)
+		cmake_package=cmake3
+		;;
+	9)
+		cmake_package=cmake
+		;;
+	*)
+		cmake_package=cmake
+		;;
+	esac
+
+	if ! rpm -q --quiet pandoc 2>/dev/null && ! dnf -q list --available pandoc >/dev/null 2>&1; then
+		echo "Unable to find pandoc in enabled repositories" >&2
+		echo "On Enterprise Linux 9, enable EPEL before running this script" >&2
+		return 1
+	fi
+
+	dnf install $dnf_args curl cpio kernel-rpm-macros rpm-build patch pandoc "$cmake_package" systemd-devel python3-devel libnl3-devel python3-Cython perl-generators
 }
 
 # Patches
@@ -963,7 +999,7 @@ main() {
 	if rpm -q --quiet python3-Cython-ohpc ; then
 		dnf remove -y python3-Cython-ohpc
 	fi
-	dnf install -y curl cpio kernel-rpm-macros rpm-build patch pandoc cmake3 systemd-devel python3-devel libnl3-devel python3-Cython perl-generators
+	install_required_dependencies
 	echo
 
 	if [ ! -f MLNX_OFED_SRC-$MLNX_OFED_VERSION.tgz ] ; then
@@ -992,10 +1028,11 @@ main() {
 	sed -i s/Release:.*/Release:\ $RDMA_CORE_NEW_VERSION/g rdma-core.spec
 	sed -i s/Source:.*/Source:\ rdma-core-%{version}-%{release}.tgz/g rdma-core.spec
 
+	dnf_args=$(dnf_install_args)
 	if ! rpm -q --quiet 'dnf-command(builddep)' && ! rpm -q --quiet dnf-plugins-core; then
-		dnf install -y dnf-plugins-core
+		dnf install $dnf_args dnf-plugins-core
 	fi
-	dnf builddep -y rdma-core.spec
+	dnf builddep $dnf_args rdma-core.spec
 
 	tar czf rdma-core-$RDMA_CORE_VERSION-$RDMA_CORE_NEW_VERSION.tgz rdma-core-$RDMA_CORE_VERSION
 	cp rdma-core-$RDMA_CORE_VERSION-$RDMA_CORE_NEW_VERSION.tgz $RPM_BUILD_ROOT/SOURCES


### PR DESCRIPTION
## Summary

Add Enterprise Linux 9 support to the patch workflow.

The script now:
- treats EL8 and EL9 as supported build environments
- installs `cmake3` on EL8 and `cmake` on EL9
- emits a clear error when `pandoc` is unavailable
- uses `--nobest` for EL9 dependency installation and `builddep` to avoid package skew on fresh cloud images

The README is updated to document the EL9 requirements: `CRB` plus `EPEL` for `pandoc`.

## Validation

- Ran `./tests/verify-releases.sh 5.8-6.0.4.2 5.9-0.5.6.0.127`
- Validated full EL9 build and install runs on Rocky Linux 9.7 VMs for:
  - `5.8-6.0.4.2`
  - `5.9-0.5.6.0.127`
- Confirmed the installed outputs include `libefa`, `libmlx4`, and `/etc/modprobe.d/mlx4.conf`
- Rechecked EL8 on Rocky Linux 8.10 with a full `5.9-0.5.6.0.127` build/install run to confirm the dependency changes did not regress the existing path

## Notes

EL9 validation currently assumes `CRB` and `EPEL` are enabled before running the script.
