### PR TITLE
Add upstream release watcher

### DIFF
--- a/.github/workflows/watch-upstream.yml
+++ b/.github/workflows/watch-upstream.yml
@@ -1,0 +1,80 @@
+name: Watch upstream MLNX OFED releases
+
+on:
+  schedule:
+    - cron: "17 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-upstream:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Check NVIDIA upstream index
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: New MLNX_OFED upstream releases detected
+          ISSUE_LABEL: upstream-update
+        run: |
+          set -eu
+
+          missing_file="${RUNNER_TEMP}/missing-mlnxofed-releases.txt"
+          body_file="${RUNNER_TEMP}/mlnxofed-upstream-issue.md"
+
+          set +e
+          sh tests/check-upstream-releases.sh > "$missing_file"
+          status=$?
+          set -e
+
+          existing_issue=$(gh issue list \
+            --state open \
+            --search "\"${ISSUE_TITLE}\" in:title" \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ "$status" -eq 0 ]; then
+            cat "$missing_file"
+            if [ -n "$existing_issue" ]; then
+              gh issue close "$existing_issue" \
+                --comment "No unsupported Enterprise Linux MLNX_OFED releases are currently detected."
+            fi
+            exit 0
+          fi
+
+          if ! grep -E '^[0-9][0-9.]*-[0-9A-Za-z.-]+$' "$missing_file" >/dev/null; then
+            cat "$missing_file"
+            exit "$status"
+          fi
+
+          {
+            echo "The NVIDIA upstream MLNX_OFED repository contains Enterprise Linux release directories that are not listed as supported here."
+            echo
+            echo "Missing releases:"
+            sed 's/^/- `/' "$missing_file" | sed 's/$/`/'
+            echo
+            echo "Source index:"
+            echo "https://linux.mellanox.com/public/repo/mlnx_ofed/"
+            echo
+            echo "Next step: add metadata for the new RPM-backed release, run the release verifier, and close this issue after merging support."
+          } > "$body_file"
+
+          gh label create "$ISSUE_LABEL" \
+            --color f29513 \
+            --description "Tracks upstream MLNX_OFED release changes" || true
+
+          if [ -n "$existing_issue" ]; then
+            gh issue edit "$existing_issue" --body-file "$body_file"
+          else
+            gh issue create \
+              --title "$ISSUE_TITLE" \
+              --body-file "$body_file" \
+              --label "$ISSUE_LABEL"
+          fi
+
+          exit 1

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ You can verify expected source markers and patched output lines against upstream
 
 `tests/verify-releases.sh 25.01-0.6.0.0 24.10-4.1.4.0 24.04-0.6.5.0 23.04-0.5.3.3 5.8-7.0.6.1 5.3-1.0.5.0 4.7-3.2.9.0`
 
+You can check for new upstream Enterprise Linux MLNX OFED releases with:
+
+`tests/check-upstream-releases.sh`
+
+The scheduled GitHub Actions workflow runs the same check weekly. If NVIDIA
+publishes a new RPM-backed Enterprise Linux release, it opens or updates one
+`upstream-update` issue.
+
 # Open Source Apache License
 
 This shell script is made available under the Apache License, Version 2.0:

--- a/tests/check-upstream-releases.sh
+++ b/tests/check-upstream-releases.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+
+set -eu
+
+case $0 in
+	*/*)
+		self_path=$0
+		;;
+	*)
+		self_path=$(command -v "$0" 2>/dev/null || printf '%s\n' "$0")
+		;;
+esac
+
+script_dir=$(CDPATH= cd "$(dirname "$self_path")" && pwd)
+repo_root=$(CDPATH= cd "$script_dir/.." && pwd)
+upstream_url=${MLNX_OFED_UPSTREAM_URL:-https://linux.mellanox.com/public/repo/mlnx_ofed}
+upstream_url=${upstream_url%/}
+
+for tool in curl comm grep sed sort tr; do
+	if ! command -v "$tool" >/dev/null 2>&1; then
+		echo "Missing required tool: $tool" >&2
+		exit 2
+	fi
+done
+
+work_root=$(mktemp -d)
+trap 'rm -rf "$work_root"' 0
+
+upstream_versions=$work_root/upstream
+known_versions=$work_root/known
+ignored_versions=$work_root/ignored
+candidate_versions=$work_root/candidates
+missing_versions=$work_root/missing
+skipped_versions=$work_root/skipped
+
+curl -fsSL "$upstream_url/" |
+	sed -n 's/.*href="\([0-9][^"/]*\)\/".*/\1/p' |
+	LC_ALL=C sort -u > "$upstream_versions"
+
+tr '`' '\n' < "$repo_root/README.md" |
+	sed -n '/^[0-9][0-9.]*-[0-9A-Za-z.-][0-9A-Za-z.-]*$/p' |
+	LC_ALL=C sort -u > "$known_versions"
+
+if [ -f "$repo_root/tests/upstream-release-ignore.txt" ]; then
+	sed 's/#.*//; s/^[	 ]*//; s/[	 ]*$//; /^[	 ]*$/d' "$repo_root/tests/upstream-release-ignore.txt" |
+		LC_ALL=C sort -u > "$ignored_versions"
+else
+	: > "$ignored_versions"
+fi
+
+comm -23 "$upstream_versions" "$known_versions" |
+	comm -23 - "$ignored_versions" > "$candidate_versions"
+: > "$missing_versions"
+: > "$skipped_versions"
+
+has_enterprise_linux_payload() {
+	release_index=$1
+
+	sed -n 's/.*href="\([^"]*\)".*/\1/p' "$release_index" |
+		grep -E '^(rhel|rocky|almalinux|ol|centos)(8|9|10)([./-]|/|$)' >/dev/null
+}
+
+has_source_rpm_payload() {
+	version=$1
+	release_index=$2
+
+	if curl -fsSL "$upstream_url/$version/SRPMS/" >/dev/null 2>&1; then
+		return 0
+	fi
+
+	grep -F "MLNX_OFED_SRC-$version.tgz" "$release_index" >/dev/null
+}
+
+while IFS= read -r version; do
+	[ -n "$version" ] || continue
+
+	release_index=$work_root/$version.index
+	if ! curl -fsSL "$upstream_url/$version/" -o "$release_index"; then
+		echo "$version: unable to read release index" >> "$skipped_versions"
+		continue
+	fi
+
+	if ! has_enterprise_linux_payload "$release_index"; then
+		echo "$version: no Enterprise Linux 8/9/10 payload" >> "$skipped_versions"
+		continue
+	fi
+
+	if ! has_source_rpm_payload "$version" "$release_index"; then
+		echo "$version: no SRPMS or standard source bundle" >> "$skipped_versions"
+		continue
+	fi
+
+	echo "$version" >> "$missing_versions"
+done < "$candidate_versions"
+
+if [ -s "$missing_versions" ]; then
+	cat "$missing_versions"
+	exit 1
+fi
+
+if [ "${CHECK_UPSTREAM_VERBOSE:-0}" = 1 ] && [ -s "$skipped_versions" ]; then
+	echo "Ignored upstream release directories:" >&2
+	cat "$skipped_versions" >&2
+fi
+
+echo "No unsupported Enterprise Linux MLNX_OFED releases detected."

--- a/tests/upstream-release-ignore.txt
+++ b/tests/upstream-release-ignore.txt
@@ -1,0 +1,5 @@
+# Public upstream directories that are intentionally outside this patcher's scope.
+#
+# MLNX_OFED 4.6 has an Enterprise Linux 8 payload, but its rdma-core tree does
+# not include the EFA provider this script re-enables in later releases.
+4.6-1.0.1.1


### PR DESCRIPTION
## Summary

- Add a portable upstream release checker for NVIDIA's public MLNX_OFED index.
- Add a weekly GitHub Actions workflow that opens or updates one issue when a new actionable Enterprise Linux release appears.
- Document the local check and ignore the known 4.6 EL8 edge case because it lacks the EFA provider used by this patcher.

## Validation

- `sh -n tests/check-upstream-releases.sh`
- `sh tests/check-upstream-releases.sh`
- `CHECK_UPSTREAM_VERBOSE=1 sh tests/check-upstream-releases.sh`
- `sh -n tests/verify-releases.sh`
- `sh -n patch-mlnxofed.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/watch-upstream.yml")'`
- `git diff --check`