### PR TITLE
watch-upstream: finish green when a release issue is filed

### DIFF
--- a/.github/workflows/watch-upstream.yml
+++ b/.github/workflows/watch-upstream.yml
@@ -77,4 +77,8 @@ jobs:
               --label "$ISSUE_LABEL"
           fi
 
-          exit 1
+          # Filing the upstream-update issue is the workflow doing its job, not a
+          # failure: the open issue is the signal that action is needed, so finish
+          # green. Genuine checker errors (missing tools, etc.) still fail the run
+          # via the exit "$status" path above.
+          exit 0


### PR DESCRIPTION
Cosmetic CI behavior change for the upstream watcher.

Today the workflow runs `exit 1` after it opens/updates the `upstream-update`
issue, so the Actions run goes red whenever there's a pending release (and can
trigger "workflow failing" notifications). That red is intentional-as-signal,
but it reads as a malfunction.

This changes that final step to `exit 0`: filing the issue is the workflow doing
its job, and the open issue itself is the signal that action is needed.

**Genuine failures still fail the run.** The `exit "$status"` guard
(`watch-upstream.yml:50-53`) is untouched, so a real checker error — e.g. a
missing tool, where the checker exits non-zero with no version list on stdout —
still falls through and the run goes red.

| Checker result | Run status |
| --- | --- |
| All clear | 🟢 green (unchanged) |
| New release found, issue filed | 🟢 green (was 🔴) |
| Genuine error (missing tool, etc.) | 🔴 red (preserved) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)